### PR TITLE
Add database indexes for SharedPrompt sorting columns

### DIFF
--- a/prisma/migrations/20250723102622_add_shared_prompt_sorting_indexes/migration.sql
+++ b/prisma/migrations/20250723102622_add_shared_prompt_sorting_indexes/migration.sql
@@ -1,0 +1,14 @@
+-- CreateIndex
+CREATE INDEX "SharedPrompt_viewCount_idx" ON "SharedPrompt"("viewCount");
+
+-- CreateIndex
+CREATE INDEX "SharedPrompt_likeCount_idx" ON "SharedPrompt"("likeCount");
+
+-- CreateIndex
+CREATE INDEX "SharedPrompt_copyCount_idx" ON "SharedPrompt"("copyCount");
+
+-- CreateIndex
+CREATE INDEX "SharedPrompt_commentCount_idx" ON "SharedPrompt"("commentCount");
+
+-- CreateIndex
+CREATE INDEX "SharedPrompt_publishedAt_likeCount_idx" ON "SharedPrompt"("publishedAt", "likeCount");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -196,6 +196,11 @@ model SharedPrompt {
   @@index([status])
   @@index([isPublished])
   @@index([publishedAt])
+  @@index([viewCount])
+  @@index([likeCount])
+  @@index([copyCount])
+  @@index([commentCount])
+  @@index([publishedAt, likeCount])
 }
 
 enum PromptVisibility {


### PR DESCRIPTION
## Summary

This PR adds database indexes to improve query performance for SharedPrompt sorting operations.

Resolves #12

## Changes

### 1. Prisma Schema Updates
Added indexes to SharedPrompt model:
- Single column indexes: viewCount, likeCount, copyCount, commentCount
- Composite index: [publishedAt, likeCount] for common query patterns

### 2. Database Migration
- Generated migration file with all necessary CREATE INDEX statements
- Migration ready to be deployed

## Performance Impact
These indexes will significantly improve:
- Marketplace sorting by popularity metrics
- Queries filtering by published status and sorting
- Overall response times for prompt listings

## Testing
- Migration tested locally
- Schema changes validated
- No breaking changes